### PR TITLE
Export client with migrate and update content type function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Easiest way to get an idea of how to use this is an example!
 ```js
 const Migrations = require('contentful-migrations')
 
-const migrate = new Migrations({
+const migration = new Migrations({
   id: 'xxx',
   token: 'xxx',
   models: 'path/to/models/folder'
 })
 
-migrate.update().then(console.log)
+migration.migrateContentTypes().then(console.log)
 ```
 
 The `id` and `token` are your contentful space id and management token, respectively. The `models` param is a path to a folder that contains one or more model definitions. The model definitions are not super well documented by contentful. First, again, an example of a model file:

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,29 +2,35 @@ const fs = require('fs')
 const fetch = require('node-fetch')
 const Throttle = require('promise-throttle')
 
-module.exports = (conf) => {
-  const client = new Client({ id: conf.id, token: conf.token })
-  const models = fs.readdirSync(conf.models).map((f) => require(`${conf.models}/${f}`))
-
-  return Promise.all(models.map((m) => client.updateContentModel(m)))
-}
-
 class Client {
-  constructor (auth) {
-    this.id = auth.id
-    this.managementToken = auth.token
-    this.url = `https://api.contentful.com/spaces/${this.id}`
-    // contentful has a 10 req/s rate limit, we stay under this comfortably
-    this.queueStore = new Throttle({
+  constructor (config) {
+    const queueStore = new Throttle({
       requestsPerSecond: 7,
       promiseImplementation: Promise
     })
-    this.queue = this.queueStore.add.bind(this.queueStore)
+
+    Object.assign(this, {
+      id: config.id,
+      managementToken: config.token,
+      spaceUrl: `https://api.contentful.com/spaces/${config.id}`,
+      modelsPath: config.models,
+      // contentful has a 10 req/s rate limit, we stay under this comfortably
+      queueStore: queueStore,
+      queue: queueStore.add.bind(queueStore)
+    })
+
     this.fetch = (...args) => this.queue(fetch.bind(this, ...args))
   }
 
+  migrateContentTypes () {
+    const models = fs.readdirSync(this.modelsPath).map((f) =>
+      require(`${this.modelsPath}/${f}`)
+    )
+    return Promise.all(models.map((m) => this.updateContentModel(m)))
+  }
+
   /**
-   * Updates a contentful model
+   * Updates a contentful content type
    * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types/content-type
    * @param {Object} opts - options passed to contentful API
    * @param {String} opts.id - content model id
@@ -32,7 +38,7 @@ class Client {
    * @param {String} opts.fields - content model fields
    * @returns {Promise} promise for updated model
    */
-  updateContentModel (opts) {
+  updateContentType (opts) {
     const id = opts.id
     delete opts.id
 
@@ -46,7 +52,7 @@ class Client {
       'Authorization': `Bearer ${this.token}`,
       'Content-Type': 'application/vnd.contentful.management.v1+json'
     }
-    const resourceUrl = `${this.url}/content_types/${id}`
+    const resourceUrl = `${this.spaceUrl}/content_types/${id}`
     const editorInterfaceUrl = `${resourceUrl}/editor_interface`
 
     // check to see if the model already exists
@@ -111,3 +117,5 @@ class Client {
     })
   }
 }
+
+module.exports = Client


### PR DESCRIPTION
1. Moves exported function into `Client` class as `migrateContentTypes` (pending addition of other functions)
2. Light refactor of `Client` constructor method to assign config props (some prop renaming).
3. Relevant Readme updates.